### PR TITLE
Port bionic beaver

### DIFF
--- a/16.04/Dockerfile
+++ b/16.04/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghifari160/apache:16.04
 
-MAINTAINER Ghifari160 <ghifari160@ghifari160.com>
+LABEL maintainer "Ghifari160 <ghifari160@ghifari160.com>"
 
 # Disable interactive functions
 ENV DEBIAN_FRONTEND noninteractive
@@ -14,7 +14,5 @@ ADD index.php /var/www/html/index.php
 
 # Install php56
 RUN apt update && apt install -y php5.6 php5.6-mysql php-gettext \
-        php5.6-mbstring php-xdebug libapache2-mod-php5.6 php5.6-dom
-
-# Cleanup after apt
-RUN rm -rf /var/lib/apt/lists/*
+        php5.6-mbstring php-xdebug libapache2-mod-php5.6 php5.6-dom && \
+    apt clean && rm -rf /var/lib/apt/lists/*

--- a/17.10/Dockerfile
+++ b/17.10/Dockerfile
@@ -1,20 +1,18 @@
 FROM ghifari160/apache:17.10
 
-MAINTAINER Ghifari160 <ghifari160@ghifari160.com>
+LABEL maintainer "Ghifari160 <ghifari160@ghifari160.com>"
 
-# disable interactive functions
+# Disable interactive functions
 ENV DEBIAN_FRONTEND noninteractive
 
-# switch locale to UTF-8 and add ppa for php56
+# Switch locale to UTF-8 and add ppa for php56
 RUN export LC_ALL=en_US.UTF-8 && add-apt-repository -y ppa:ondrej/php
 
-# add the custom default page
+# Add the custom default page
 RUN rm /var/www/html/index.html
 ADD index.php /var/www/html/index.php
 
-# install php56
+# Install php56
 RUN apt update && apt install -y php5.6 php5.6-mysql php-gettext \
-        php5.6-mbstring php-xdebug libapache2-mod-php5.6 php5.6-dom
-
-# cleanup after apt
-RUN rm -rf /var/lib/apt/lists/*
+        php5.6-mbstring php-xdebug libapache2-mod-php5.6 php5.6-dom && \
+    apt clean && rm -rf /var/lib/apt/lists/*

--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -1,0 +1,18 @@
+FROM ghifari160/apache:18.04
+
+LABEL maintainer "Ghifari160 <ghifari160@ghifari160.com>"
+
+# Disable interactive functions
+ENV DEBIAN_FRONTEND noninteractive
+
+# Switch locale to UTF-8 and add ppa for php56
+RUN export LC_ALL=en_US.UTF-8 && add-apt-repository -y ppa:ondrej/php
+
+# Add the custom default page
+RUN rm /var/www/html/index.html
+ADD index.php /var/www/html/index.php
+
+# Install php56
+RUN apt update && apt install -y php5.6 php5.6-mysql php-gettext \
+        php5.6-mbstring php-xdebug libapache2-mod-php5.6 php5.6-dom && \
+    apt clean && rm -rf /var/lib/apt/lists/*

--- a/18.04/index.php
+++ b/18.04/index.php
@@ -1,0 +1,3 @@
+<?php
+phpinfo();
+?>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-16.04/Dockerfile
+18.04/Dockerfile

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # A Better PHP Image for Docker #
-[![Docker Hub: ghifari160/apache-php56](https://img.shields.io/badge/docker%20hub-ghifari160%2Fapache%2Fphp56-ABD8EB.svg)](https://hub.docker.com/r/ghifari160/apache-php56)
+[![Docker Hub: ghifari160/apache-php56](https://img.shields.io/badge/docker%20hub-ghifari160%2Fapache--php56-ABD8EB.svg)](https://hub.docker.com/r/ghifari160/apache-php56)
 [![](https://images.microbadger.com/badges/image/ghifari160/apache-php56.svg)](https://microbadger.com/images/ghifari160/apache-php56 "Get your own image badge on microbadger.com")
 
 This image is not just another PHP5.6 image for Docker.
 
+Looking for a PHP5.5 image for Docker? Check [ghifari160/apache-php55].
+
 ## Why Use This Image ##
-This image is based on [ghifari160/apache](https://github.com/ghifari160/docker-apache).
-ghifari160/apache forces Apache to run in the foreground and output its log into
-the container's stdio.
+This image is based on [ghifari160/apache], which forces Apache to run in the
+foreground and output its log into the container's stdio.
 
 ## Installation ##
 By default, this image should be run as a daemon.
@@ -42,8 +43,24 @@ Example:
 docker run -d -p 8080:80 ghifari160/apache-php56
 ```
 
+#### macOS permission fixes
+On macOS, shared volumes remains owned by the host user and group. Permissions
+on these shared volumes are also determined by the host, unchangeable from
+guest. On the home directory, the default owner and permission are
+`<user>:staff` and `755`. Apache needs write access to its files and
+directories. A workaround is to set the `www-data` UID and GID to `1000` and
+`50`. The init script will do this if the value of `G16_MACOS` is `yes`. Use
+the parameter `-e G16_MACOS=yes` to enable this workaround. Example:
+```
+docker run -d -e G16_MACOS=yes ghifari160/apache
+```
+
 ## Tags ##
 | Tags                      | Ubuntu Version | Size |
 |---------------------------|----------------|------|
-| `latest` `16.04` `xenial` | 16.04          | [![](https://images.microbadger.com/badges/image/ghifari160/apache-php56:16.04.svg)](https://microbadger.com/images/ghifari160/apache-php56:16.04 "Get your own image badge on microbadger.com") |
-| `17.10` `artful`          | 17.10          | [![](https://images.microbadger.com/badges/image/ghifari160/apache-php56:17.10.svg)](https://microbadger.com/images/ghifari160/apache-php56:17.10 "Get your own image badge on microbadger.com") |
+| `16.04` `xenial`          | 16.04          | [![](https://images.microbadger.com/badges/image/ghifari160/apache-php56:16.04.svg)](https://microbadger.com/images/ghifari160/apache-php56:16.04 "Get your own image badge on microbadger.com")|
+| `17.10` `artful`          | 17.10          | [![](https://images.microbadger.com/badges/image/ghifari160/apache-php56:17.10.svg)](https://microbadger.com/images/ghifari160/apache-php56:17.10 "Get your own image badge on microbadger.com")|
+| `latest` `18.04` `bionic` | 18.04          |[![](https://images.microbadger.com/badges/image/ghifari160/apache-php56.svg)](https://microbadger.com/images/ghifari160/apache-php56 "Get your own image badge on microbadger.com")|
+
+[ghifari160/apache]: https://github.com/ghifari160/docker-apache
+[ghifari160/apache-php55]: https://github.com/ghifari160/docker-apache-php55

--- a/index.php
+++ b/index.php
@@ -1,1 +1,1 @@
-16.04/index.php
+18.04/index.php


### PR DESCRIPTION
This PR ports Apache2 and PHP5.6 stack running on Ubuntu 18.04 LTS to an image for Docker. The `latest` tag should update to follow this release.